### PR TITLE
Fixed race condition in quota reload logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,8 +26,6 @@ var (
 func loadQuotaFiles(quotaDir string) error {
 	log.Printf("Loading configuration files from [%s]\n", quotaDir)
 
-	confLock.Lock()
-	defer confLock.Unlock()
 	glob := fmt.Sprintf("%s%c%s", quotaDir, filepath.Separator, "*.xml")
 	files, _ := filepath.Glob(glob)
 	if len(files) == 0 {
@@ -49,9 +47,15 @@ func loadQuotaFile(file string) {
 		log.Printf("Failed to load configuration from [%s]: %v", fileName, err)
 		return
 	}
+	updateQuota(quotaName, browsers)
+	log.Printf("Loaded configuration from [%s]:\n%v\n", file, browsers)
+}
+
+func updateQuota(quotaName string, browsers Browsers) {
+	confLock.Lock()
+	defer confLock.Unlock()
 	quota[quotaName] = browsers
 	routes = appendRoutes(routes, &browsers)
-	log.Printf("Loaded configuration from [%s]:\n%v\n", file, browsers)
 }
 
 func init() {

--- a/proxy.go
+++ b/proxy.go
@@ -236,7 +236,10 @@ func proxy(r *http.Request) {
 	if len(r.URL.Path) > tail {
 		sum := r.URL.Path[head:tail]
 		proxyPath := r.URL.Path[:head] + r.URL.Path[tail:]
-		if h, ok := routes[sum]; ok {
+		confLock.RLock()
+		defer confLock.RUnlock()
+		h, ok := routes[sum]
+		if ok {
 			if body, err := ioutil.ReadAll(r.Body); err == nil {
 				r.Body.Close()
 				var msg map[string]interface{}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -201,8 +201,7 @@ func TestCreateSessionNoHosts(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	rsp, err := createSession(`{"desiredCapabilities":{"browserName":"browser", "version":"1.0"}}`)
 	AssertThat(t, err, Is{nil})
@@ -221,8 +220,7 @@ func TestCreateSessionHostDown(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	rsp, err := createSession(`{"desiredCapabilities":{"browserName":"browser", "version":"1.0"}}`)
 	AssertThat(t, err, Is{nil})
@@ -265,8 +263,7 @@ func TestStartSession(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	rsp, err := createSession(`{"desiredCapabilities":{"browserName":"browser", "version":"1.0"}}`)
 
@@ -296,8 +293,7 @@ func TestStartSessionWithJsonSpecChars(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	rsp, err := createSession(`{"desiredCapabilities":{"browserName":"{browser}", "version":"1.0"}}`)
 
@@ -333,8 +329,7 @@ func TestStartSessionWithPrefixVersion(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	createSession(`{"desiredCapabilities":{"browserName":"browser", "version":"1"}}`)
 }
@@ -372,8 +367,7 @@ func TestStartSessionWithDefaultVersion(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	createSession(`{"desiredCapabilities":{"browserName":"browser", "version":""}}`)
 }
@@ -404,8 +398,7 @@ func TestClientClosedConnection(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	r, _ := http.NewRequest(http.MethodPost, gridrouter("/wd/hub/session"), bytes.NewReader([]byte(`{"desiredCapabilities":{"browserName":"browser", "version":"1.0"}}`)))
 	r.SetBasicAuth("test", "test")
@@ -444,8 +437,7 @@ func TestStartSessionFail(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	rsp, err := createSession(`{"desiredCapabilities":{"browserName":"browser", "version":"1.0"}}`)
 
@@ -476,8 +468,7 @@ func TestStartSessionBrowserFail(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	rsp, err := createSession(`{"desiredCapabilities":{"browserName":"browser", "version":"1.0"}}`)
 
@@ -508,8 +499,7 @@ func TestStartSessionBrowserFailUnknownError(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	rsp, err := createSession(`{"desiredCapabilities":{"browserName":"browser", "version":"1.0"}}`)
 
@@ -540,8 +530,7 @@ func TestStartSessionBrowserFailWrongValue(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	rsp, err := createSession(`{"desiredCapabilities":{"browserName":"browser", "version":"1.0"}}`)
 
@@ -572,8 +561,7 @@ func TestStartSessionBrowserFailWrongMsg(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	rsp, err := createSession(`{"desiredCapabilities":{"browserName":"browser", "version":"1.0"}}`)
 
@@ -602,8 +590,7 @@ func TestDeleteSession(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	r, _ := http.NewRequest("DELETE", gridrouter("/wd/hub/session/"+node.sum()+"123"), nil)
 	r.SetBasicAuth("test", "test")
@@ -635,8 +622,7 @@ func TestProxyRequest(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	r, _ := http.NewRequest("GET", gridrouter("/wd/hub/session/"+node.sum()+"123"), nil)
 	r.SetBasicAuth("test", "test")
@@ -670,8 +656,10 @@ func TestProxyJsonRequest(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	go func() {
+		// To detect race conditions in quota loading
+		updateQuota(user, browsers)
+	}()
 
 	doBasicHTTPRequest("POST", gridrouter("/wd/hub/session/"+node.sum()+"123"), bytes.NewReader([]byte(`{"sessionId":"123"}`)))
 }
@@ -700,8 +688,7 @@ func TestProxyPlainRequest(t *testing.T) {
 				}},
 			}},
 		}}}}
-	quota[user] = browsers
-	routes = appendRoutes(routes, &browsers)
+	updateQuota(user, browsers)
 
 	doBasicHTTPRequest("POST", gridrouter("/wd/hub/session/"+node.sum()+"123"), bytes.NewReader([]byte("request")))
 }
@@ -752,4 +739,8 @@ func TestRequestAuthForwarded(t *testing.T) {
 	r.Header.Set("X-Forwarded-For", "proxy")
 	r.SetBasicAuth("user", "password")
 	http.DefaultClient.Do(r)
+}
+
+func TestConcurrentQuotaReadAndWrite(t *testing.T) {
+
 }


### PR DESCRIPTION
```
Jan 11 18:44:04 localhost docker/ggr[974]: fatal error: concurrent map read and map write
Jan 11 18:44:04 localhost docker/ggr[974]:
Jan 11 18:44:04 localhost docker/ggr[974]: goroutine 142567603 [running]:
Jan 11 18:44:04 localhost docker/ggr[974]: runtime.throw(0x6de4be, 0x21)
Jan 11 18:44:04 localhost docker/ggr[974]: #011/usr/lib/go-1.7/src/runtime/panic.go:566 +0x95 fp=0xc4307cf8a0 sp=0xc4307cf880
Jan 11 18:44:04 localhost docker/ggr[974]: runtime.mapaccess2_faststr(0x68b600, 0xc42000cf90, 0xc4210a6e15, 0x20, 0x2d, 0xc42aaeb080)
Jan 11 18:44:04 localhost docker/ggr[974]: #011/usr/lib/go-1.7/src/runtime/hashmap_fast.go:306 +0x52b fp=0xc4307cf900 sp=0xc4307cf8a0
Jan 11 18:44:04 localhost docker/ggr[974]: main.proxy(0xc445e1a4b0)
Jan 11 18:44:04 localhost docker/ggr[974]: #011/root/vania-pooh/go/src/github.com/aandryashin/ggr/proxy.go:238 +0x13e fp=0xc4307cfab8 sp=0xc4307cf900
Jan 11 18:44:04 localhost docker/ggr[974]: net/http/httputil.(*ReverseProxy).ServeHTTP(0xc42048cd80, 0x7fcec0, 0xc42a5aef70, 0xc4212d6d20)
Jan 11 18:44:04 localhost docker/ggr[974]: #011/usr/lib/go-1.7/src/net/http/httputil/reverseproxy.go:181 +0x13d fp=0xc4307cfcb0 sp=0xc4307cfab8
```